### PR TITLE
Unify API call signature for global and regional features

### DIFF
--- a/app/siibra_api.py
+++ b/app/siibra_api.py
@@ -184,6 +184,7 @@ def get_regional_feature(atlas_id,parcellation_id,region_id,modality_id):
             "@id": receptor_pr.name,
             "name": receptor_pr.name,
             "info": receptor_pr.info,
+            "__receptor_symbols": receptors_export.RECEPTOR_SYMBOLS,
             "__files": receptor_pr.files,
             "__data": {
                 "__profiles": receptor_pr.profiles,

--- a/app/siibra_api.py
+++ b/app/siibra_api.py
@@ -21,7 +21,7 @@ from fastapi.encoders import jsonable_encoder
 from .request_utils import query_data, create_atlas, find_region_via_id
 
 from siibra import features, modalities
-from siibra.features import feature as feature_export,classes as feature_classes, connectivity as connectivity_export
+from siibra.features import feature as feature_export,classes as feature_classes, connectivity as connectivity_export, receptors as receptors_export
 from memoization import cached
 
 # FastApi router to create rest endpoints
@@ -149,23 +149,50 @@ def get_gene_expression(region, gene):
         raise HTTPException(status_code=400, detail='Invalid gene: {}'.format(gene))
 
 @cached
-def get_connectivty_profile(atlas_id,parcellation_id,region_id):
+def get_regional_feature(atlas_id,parcellation_id,region_id,modality_id):
+    # select atlas by id
+    if modality_id not in feature_classes:
+        # modality_id not found in feature_classes
+        return []
+    
+    if not issubclass(feature_classes[modality_id], feature_export.RegionalFeature):
+        # modality_id is not a global feature, return empty array
+        return []
+
 
     # select atlas by id
     atlas = create_atlas(atlas_id)
     # select atlas parcellation
     atlas.select_parcellation(parcellation_id)
     regions = find_region_via_id(atlas,region_id)
+
     if len(regions) == 0:
         raise HTTPException(status_code=401, detail=f'Region with id {region_id} not found!')
+    
     atlas.select_region(regions[0])
-    conn_profiles = atlas.get_features(modalities.ConnectivityProfile)
-    return [{
-        "src_name": conn_pr.src_name,
-        "column_names": conn_pr.column_names,
-        "src_info": conn_pr.src_info,
-        "profile": conn_pr.profile,
-    } for conn_pr in conn_profiles ]
+    got_features=atlas.get_features(modality_id)
+    if feature_classes[modality_id] == connectivity_export.ConnectivityProfile:
+        return [{
+            "@id": conn_pr.src_name,
+            "src_name": conn_pr.src_name,
+            "src_info": conn_pr.src_info,
+            "__column_names": conn_pr.column_names,
+            "__profile": conn_pr.profile,
+        } for conn_pr in got_features ]
+    if feature_classes[modality_id] == receptors_export.ReceptorDistribution:
+        return [{
+            "@id": receptor_pr.name,
+            "name": receptor_pr.name,
+            "info": receptor_pr.info,
+            "__files": receptor_pr.files,
+            "__data": {
+                "__profiles": receptor_pr.profiles,
+                "__autoradiographs": receptor_pr.autoradiographs,
+                "__fingerprint": receptor_pr.fingerprint,
+                "__profile_unit": receptor_pr.profile_unit,
+            },
+        } for receptor_pr in got_features ]
+    raise NotImplementedError(f'feature {modality_id} has not yet been implmented')
 
 @cached
 def get_global_features(atlas_id,parcellation_id,modality_id):


### PR DESCRIPTION
now, `/features` will always return a list of valid modalities
`/features/{modality}` will return a list of summerized modality features
`/features/{modality}/{modality_id}` will return feature details (connectivity full profile, receptor profile etc)