### PR TITLE
feat: explicit detail flag when fetching regional datasets

### DIFF
--- a/app/ebrains_token.py
+++ b/app/ebrains_token.py
@@ -24,7 +24,7 @@ from .siibra_custom_exception import SiibraCustomException
 _client_id = os.getenv('EBRAINS_IAM_CLIENT_ID')
 _client_secret = os.getenv('EBRAINS_IAM_CLIENT_SECRET')
 _refresh_token = os.getenv('EBRAINS_IAM_REFRESH_TOKEN')
-
+_access_token=os.getenv('EBRAINS_IAM_ACCESS_TOKEN')
 
 class TokenWrapper:
     def __init__(
@@ -110,6 +110,8 @@ token_wrapper = TokenWrapper(
 
 
 def get_public_token():
+    if _access_token is not None:
+        return _access_token
     return token_wrapper.get_token()
 
 

--- a/app/parcellation_api.py
+++ b/app/parcellation_api.py
@@ -124,7 +124,7 @@ def get_all_parcellations(atlas_id: str, request: Request):
 
 @router.get(ATLAS_PATH +
             '/{atlas_id:path}/parcellations/{parcellation_id:path}/regions', tags=['parcellations'])
-@fanout_cache.memoize(typed=True, expire=60 * 60)
+@fanout_cache.memoize(typed=True)
 def get_all_regions_for_parcellation_id(
         atlas_id: str,
         parcellation_id: str,
@@ -263,7 +263,7 @@ def parse_region_selection(
 @router.get(ATLAS_PATH +
             '/{atlas_id:path}/parcellations/{parcellation_id:path}/regions/{region_id:path}/regional_map/info',
             tags=['parcellations'])
-@fanout_cache.memoize(typed=True, expire=60 * 60)
+@fanout_cache.memoize(typed=True)
 def get_regional_map_info(
         atlas_id: str,
         parcellation_id: str,
@@ -290,7 +290,7 @@ def get_regional_map_info(
 @router.get(ATLAS_PATH +
             '/{atlas_id:path}/parcellations/{parcellation_id:path}/regions/{region_id:path}/regional_map/map',
             tags=['parcellations'])
-@fanout_cache.memoize(typed=True, expire=60 * 60)
+@fanout_cache.memoize(typed=True)
 def get_regional_map_file(
         atlas_id: str,
         parcellation_id: str,

--- a/app/parcellation_api.py
+++ b/app/parcellation_api.py
@@ -194,21 +194,17 @@ def get_regional_modality_by_id(
     Returns all features for a region. The returned feature is defined by the given modality type and modality id.
     """
     regional_features = get_regional_feature(
-        atlas_id, parcellation_id, region_id, modality, gene=gene)
+        atlas_id, parcellation_id, region_id, modality, feature_id=modality_id, detail=True, gene=gene)
 
-    found_conn_pr = [{
-        key: val() if callable(val) else val for key, val in f.items()
-    } for f in regional_features if f['@id'] == modality_id]
-
-    if len(found_conn_pr) == 0:
+    if len(regional_features) == 0:
         raise HTTPException(
             status_code=404,
             detail=f'modality with id {modality_id} not found')
-    if len(found_conn_pr) != 1:
+    if len(regional_features) != 1:
         raise HTTPException(
             status_code=400,
             detail=f'modality with id {modality_id} has multiple matches')
-    return found_conn_pr[0]
+    return regional_features[0]
 
 
 @router.get(ATLAS_PATH +

--- a/app/parcellation_api.py
+++ b/app/parcellation_api.py
@@ -226,13 +226,9 @@ def get_feature_modality_for_region(
     """
 
     regional_features = get_regional_feature(
-        atlas_id, parcellation_id, region_id, modality, gene=gene)
+        atlas_id, parcellation_id, region_id, modality, detail=False, gene=gene)
 
-    # in summary search, only search for basic data (filter out all keys
-    # prepended by __)
-    return [{key: val() if callable(val) else val for key, val in f.items(
-    ) if not re.search(r"^__", key)} for f in regional_features]
-
+    return regional_features
 
 def parse_region_selection(
         atlas_id: str,

--- a/app/request_utils.py
+++ b/app/request_utils.py
@@ -242,6 +242,7 @@ def get_regional_feature(
         parcellation_id,
         region_id,
         modality_id,
+        detail=True,
         gene=None):
     # select atlas by id
     if modality_id not in feature_classes:
@@ -289,17 +290,21 @@ def get_regional_feature(
         return [{
             '@id': kg_rf_f.id,
             'src_name': kg_rf_f.name,
-            '__detail': kg_rf_f.detail
+            **({
+                '__detail': kg_rf_f.detail
+            } if detail else {})
         } for kg_rf_f in got_features]
     if feature_classes[modality_id] == genes_export.GeneExpression:
         return [{
             '@id': hashlib.md5(str(gene_feat).encode("utf-8")).hexdigest(),
-            '__donor_info': gene_feat.donor_info,
-            '__gene': gene_feat.gene,
-            '__probe_ids': gene_feat.probe_ids,
-            '__mri_coord': gene_feat.mri_coord,
-            '__z_scores': gene_feat.z_scores,
-            '__expression_levels': gene_feat.expression_levels
+            **({
+                '__donor_info': gene_feat.donor_info,
+                '__gene': gene_feat.gene,
+                '__probe_ids': gene_feat.probe_ids,
+                '__mri_coord': gene_feat.mri_coord,
+                '__z_scores': gene_feat.z_scores,
+                '__expression_levels': gene_feat.expression_levels
+            } if detail else {}),
         } for gene_feat in got_features]
     if feature_classes[modality_id] == connectivity_export.ConnectivityProfile:
         return [{
@@ -308,22 +313,26 @@ def get_regional_feature(
             "src_info": conn_pr.src_info,
             "kgSchema": conn_pr.kg_schema,
             "kgId": conn_pr.kg_id,
-            "__column_names": conn_pr.column_names,
-            "__profile": conn_pr.profile,
+            **({
+                "__column_names": conn_pr.column_names,
+                "__profile": conn_pr.profile,
+            } if detail else {}),
         } for conn_pr in got_features]
     if feature_classes[modality_id] == receptors_export.ReceptorDistribution:
         return [{
             "@id": receptor_pr.name,
             "name": receptor_pr.name,
             "info": receptor_pr.info,
-            "__receptor_symbols": receptors_export.RECEPTOR_SYMBOLS,
-            "__files": receptor_pr.files,
-            "__data": {
-                "__profiles": receptor_pr.profiles,
-                "__autoradiographs": receptor_pr.autoradiographs,
-                "__fingerprint": receptor_pr.fingerprint,
-                "__profile_unit": receptor_pr.profile_unit,
-            },
+            **({
+                "__receptor_symbols": receptors_export.RECEPTOR_SYMBOLS,
+                "__files": receptor_pr.files,
+                "__data": {
+                    "__profiles": receptor_pr.profiles,
+                    "__autoradiographs": receptor_pr.autoradiographs,
+                    "__fingerprint": receptor_pr.fingerprint,
+                    "__profile_unit": receptor_pr.profile_unit,
+                },
+            } if detail else {}),
         } for receptor_pr in got_features]
     raise HTTPException(
         status_code=501,

--- a/app/request_utils.py
+++ b/app/request_utils.py
@@ -236,7 +236,7 @@ SUPPORTED_FEATURES = [
     ebrainsquery_export.EbrainsRegionalDataset]
 
 
-@fanout_cache.memoize(typed=True, expire=60 * 60)
+@fanout_cache.memoize(typed=True)
 def get_regional_feature(
         atlas_id,
         parcellation_id,
@@ -339,7 +339,7 @@ def get_regional_feature(
         detail=f'feature {modality_id} has not yet been implmented')
 
 
-@fanout_cache.memoize(typed=True, expire=60 * 60)
+@fanout_cache.memoize(typed=True)
 def get_global_features(atlas_id, parcellation_id, modality_id):
     if modality_id not in feature_classes:
         # modality_id not found in feature_classes

--- a/app/request_utils.py
+++ b/app/request_utils.py
@@ -243,6 +243,7 @@ def get_regional_feature(
         region_id,
         modality_id,
         detail=True,
+        feature_id=None,
         gene=None):
     # select atlas by id
     if modality_id not in feature_classes:
@@ -286,44 +287,51 @@ def get_regional_feature(
             status_code=404,
             detail=f'Could not get features for region with id {region_id}')
 
+    shaped_features = None
     if feature_classes[modality_id] == ebrainsquery_export.EbrainsRegionalDataset:
-        return [{
-            '@id': kg_rf_f.id,
-            'src_name': kg_rf_f.name,
-            **({
-                '__detail': kg_rf_f.detail
-            } if detail else {})
+        shaped_features=[{
+            'summary': {
+                '@id': kg_rf_f.id,
+                'src_name': kg_rf_f.name,
+            },
+            'get_detail': lambda: { '__detail': kg_rf_f.detail },
         } for kg_rf_f in got_features]
     if feature_classes[modality_id] == genes_export.GeneExpression:
-        return [{
-            '@id': hashlib.md5(str(gene_feat).encode("utf-8")).hexdigest(),
-            **({
+        shaped_features=[{
+            'summary': {
+                '@id': hashlib.md5(str(gene_feat).encode("utf-8")).hexdigest(),
+            },
+            'get_detail': lambda : { 
                 '__donor_info': gene_feat.donor_info,
                 '__gene': gene_feat.gene,
                 '__probe_ids': gene_feat.probe_ids,
                 '__mri_coord': gene_feat.mri_coord,
                 '__z_scores': gene_feat.z_scores,
                 '__expression_levels': gene_feat.expression_levels
-            } if detail else {}),
+             },
         } for gene_feat in got_features]
     if feature_classes[modality_id] == connectivity_export.ConnectivityProfile:
-        return [{
-            "@id": conn_pr.src_name,
-            "src_name": conn_pr.src_name,
-            "src_info": conn_pr.src_info,
-            "kgSchema": conn_pr.kg_schema,
-            "kgId": conn_pr.kg_id,
-            **({
+        shaped_features=[{
+            'summary': {
+                "@id": conn_pr.src_name,
+                "src_name": conn_pr.src_name,
+                "src_info": conn_pr.src_info,
+                "kgSchema": conn_pr.kg_schema,
+                "kgId": conn_pr.kg_id,
+            },
+            'get_detail': lambda : { 
                 "__column_names": conn_pr.column_names,
                 "__profile": conn_pr.profile,
-            } if detail else {}),
+             }
         } for conn_pr in got_features]
     if feature_classes[modality_id] == receptors_export.ReceptorDistribution:
-        return [{
-            "@id": receptor_pr.name,
-            "name": receptor_pr.name,
-            "info": receptor_pr.info,
-            **({
+        shaped_features=[{
+            'summary': {
+                "@id": receptor_pr.name,
+                "name": receptor_pr.name,
+                "info": receptor_pr.info,
+            },
+            'get_detail': lambda : { 
                 "__receptor_symbols": receptors_export.RECEPTOR_SYMBOLS,
                 "__files": receptor_pr.files,
                 "__data": {
@@ -332,11 +340,20 @@ def get_regional_feature(
                     "__fingerprint": receptor_pr.fingerprint,
                     "__profile_unit": receptor_pr.profile_unit,
                 },
-            } if detail else {}),
+             }
         } for receptor_pr in got_features]
-    raise HTTPException(
-        status_code=501,
-        detail=f'feature {modality_id} has not yet been implmented')
+
+    if shaped_features is None:
+        raise HTTPException(
+            status_code=501,
+            detail=f'feature {modality_id} has not yet been implmented')
+
+    if feature_id is not None:
+        shaped_features = [ f for f in shaped_features if f['summary']['@id'] == feature_id]
+    return [{
+        **f['summary'],
+        **(f['get_detail']() if detail else {})
+    } for f in shaped_features ]
 
 
 @fanout_cache.memoize(typed=True)


### PR DESCRIPTION
Currently, fetching regional datasets meant fetching the entire dictionary, then filter according to key.

This behaviour is non performant (especially for ebrainsdatasets, which requires independent http call to fetch details), and the filtering of the data is by convention (prepend dunder to property)

This PR how introduces an explicit `detail` flag which fixes both issues.

**note** detail defaults to True, to be as backwards compatible as possible.
