### PR TITLE
feat: include preheat of ebrains features

### DIFF
--- a/.openshift/branch-deploy-template.yml
+++ b/.openshift/branch-deploy-template.yml
@@ -23,71 +23,70 @@ objects:
           app: siibra-api-branch-deploy
           deploymentconfig: siibra-api-branch-deploy-${SANITIZED_BRANCH_NAME}
       spec:
-          containers:
-          - env:
-            - name: SESSION_SECRET
-              value: ${SESSION_SECRET}
+        containers:
+        - env:
+          - name: SESSION_SECRET
+            value: ${SESSION_SECRET}
 
-            - name: EBRAINS_IAM_CLIENT_ID
-              valueFrom: 
-                configMapKeyRef:
-                  name: hbp-oauth-config-map
-                  key: HBP_CLIENTID
-            - name: EBRAINS_IAM_CLIENT_SECRET
-              valueFrom: 
-                configMapKeyRef:
-                  name: hbp-oauth-config-map
-                  key: HBP_CLIENTSECRET
-            - name: EBRAINS_IAM_REFRESH_TOKEN
-              valueFrom: 
-                configMapKeyRef:
-                  name: hbp-oauth-config-map
-                  key: REFRESH_TOKEN
-                  
-            envFrom:
-            - configMapRef:
-                name: siibra-config-overwrite
-              prefix: SIIBRA_CONFIG_
+          - name: EBRAINS_IAM_CLIENT_ID
+            valueFrom: 
+              configMapKeyRef:
+                name: hbp-oauth-config-map
+                key: HBP_CLIENTID
+          - name: EBRAINS_IAM_CLIENT_SECRET
+            valueFrom: 
+              configMapKeyRef:
+                name: hbp-oauth-config-map
+                key: HBP_CLIENTSECRET
+          - name: EBRAINS_IAM_REFRESH_TOKEN
+            valueFrom: 
+              configMapKeyRef:
+                name: hbp-oauth-config-map
+                key: REFRESH_TOKEN
+                
+          envFrom:
+          - configMapRef:
+              name: siibra-config-overwrite
+            prefix: SIIBRA_CONFIG_
 
-            image: "docker-registry.ebrains.eu/siibra/siibra-api:${BRANCH_NAME}"
-            imagePullPolicy: Always
-            name: siibra-api-${SANITIZED_BRANCH_NAME}
-            ports:
-            - containerPort: 5000
-              protocol: TCP
-            resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
-          dnsPolicy: ClusterFirst
-          restartPolicy: Always
-          schedulerName: default-scheduler
-
-          # okd seems to impose a 10 minute on pod being alive.
-          # or it will kill the pod even if the failureThreshold is set to greater than that
+          # this is sucky
+          # in future, either change siibra-python to use diskcache/rediscache
+          # or use startupProbe (openshift 4.4+) to allow >600 sec container startup time
           livenessProbe:
-            failureThreshold: 60
+            failureThreshold: 10
             httpGet:
               path: /
               port: 5000
               scheme: HTTP
-            initialDelaySeconds: 10
+            initialDelaySeconds: 580
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 10
-          # 20 minutes to get ready
-          # first check at 1 minute after pod init
           readinessProbe:
-            failureThreshold: 120
+            failureThreshold: 10
             httpGet:
-              path: /ready
+              path: /
               port: 5000
               scheme: HTTP
-            initialDelaySeconds: 60
+            initialDelaySeconds: 300
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 10
-          securityContext: {}
-          terminationGracePeriodSeconds: 30
+
+          image: "docker-registry.ebrains.eu/siibra/siibra-api:${BRANCH_NAME}"
+          imagePullPolicy: Always
+          name: siibra-api-${SANITIZED_BRANCH_NAME}
+          ports:
+          - containerPort: 5000
+            protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
 - apiVersion: v1
   kind: Service
   metadata:

--- a/.openshift/branch-deploy-template.yml
+++ b/.openshift/branch-deploy-template.yml
@@ -61,6 +61,31 @@ objects:
           dnsPolicy: ClusterFirst
           restartPolicy: Always
           schedulerName: default-scheduler
+
+          # okd seems to impose a 10 minute on pod being alive.
+          # or it will kill the pod even if the failureThreshold is set to greater than that
+          livenessProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /
+              port: 5000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          # 20 minutes to get ready
+          # first check at 1 minute after pod init
+          readinessProbe:
+            failureThreshold: 120
+            httpGet:
+              path: /ready
+              port: 5000
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
           securityContext: {}
           terminationGracePeriodSeconds: 30
 - apiVersion: v1

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,3 +19,5 @@ ch = logging.StreamHandler()
 formatter = logging.Formatter('[%(name)s:%(levelname)s]  %(message)s')
 ch.setFormatter(formatter)
 logger.addHandler(ch)
+
+logger.setLevel('INFO')

--- a/app/parcellation_api.py
+++ b/app/parcellation_api.py
@@ -28,15 +28,24 @@ from .request_utils import get_spaces_for_parcellation, get_base_url_from_reques
 from .request_utils import get_global_features, get_regional_feature, get_path_to_regional_map
 from .diskcache import fanout_cache
 from .ebrains_token import get_public_token
+from . import logger
 
+preheat_flag=False
+
+def get_preheat_status():
+    global preheat_flag
+    return preheat_flag
 
 def preheat(id=None):
+    logger.info('--start parcellation preheat--')
     auth = Authentication.instance()
     public_token = get_public_token()
     auth.set_token(public_token)
     
     EbrainsRegionalFeatureCls=feature_classes[feature_modalities.EbrainsRegionalDataset]
-    EbrainsRegionalFeatureCls.preheat(id)
+    if hasattr(EbrainsRegionalFeatureCls, 'preheat') and callable(EbrainsRegionalFeatureCls.preheat):
+        EbrainsRegionalFeatureCls.preheat(id)
+        logger.info('--end parcellation preheat--')
 
 router = APIRouter()
 
@@ -476,6 +485,3 @@ def get_parcellation_by_id(
 
 
 # endregion
-print('--preheat start--')
-preheat()
-print('--preheat complete--')

--- a/app/parcellation_api.py
+++ b/app/parcellation_api.py
@@ -21,11 +21,22 @@ from starlette.responses import PlainTextResponse, FileResponse
 from fastapi.encoders import jsonable_encoder
 from siibra import spaces as siibra_spaces
 from siibra.features import feature as feature_export, classes as feature_classes, modalities as feature_modalities
+from siibra.ebrains import Authentication
 from .atlas_api import ATLAS_PATH
 from .request_utils import split_id, create_atlas, find_space_by_id, find_region_via_id, create_region_json_response
 from .request_utils import get_spaces_for_parcellation, get_base_url_from_request, siibra_custom_json_encoder
 from .request_utils import get_global_features, get_regional_feature, get_path_to_regional_map
 from .diskcache import fanout_cache
+from .ebrains_token import get_public_token
+
+
+def preheat(id=None):
+    auth = Authentication.instance()
+    public_token = get_public_token()
+    auth.set_token(public_token)
+    
+    EbrainsRegionalFeatureCls=feature_classes[feature_modalities.EbrainsRegionalDataset]
+    EbrainsRegionalFeatureCls.preheat(id)
 
 router = APIRouter()
 
@@ -465,3 +476,6 @@ def get_parcellation_by_id(
 
 
 # endregion
+print('--preheat start--')
+preheat()
+print('--preheat complete--')

--- a/app/parcellation_api.py
+++ b/app/parcellation_api.py
@@ -37,6 +37,7 @@ def get_preheat_status():
     return preheat_flag
 
 def preheat(id=None):
+    global preheat_flag
     logger.info('--start parcellation preheat--')
     auth = Authentication.instance()
     public_token = get_public_token()
@@ -46,6 +47,9 @@ def preheat(id=None):
     if hasattr(EbrainsRegionalFeatureCls, 'preheat') and callable(EbrainsRegionalFeatureCls.preheat):
         EbrainsRegionalFeatureCls.preheat(id)
         logger.info('--end parcellation preheat--')
+    else:
+        logger.info('--siibra-python does not suppport preheat. exiting--')
+    preheat_flag=True
 
 router = APIRouter()
 

--- a/app/request_utils.py
+++ b/app/request_utils.py
@@ -295,14 +295,15 @@ def get_regional_feature(
                 '@id': kg_rf_f.id,
                 'src_name': kg_rf_f.name,
             },
-            'get_detail': lambda: { '__detail': kg_rf_f.detail },
+            'get_detail': lambda kg_rf_f: { '__detail': kg_rf_f.detail },
+            'instance': kg_rf_f,
         } for kg_rf_f in got_features]
     if feature_classes[modality_id] == genes_export.GeneExpression:
         shaped_features=[{
             'summary': {
                 '@id': hashlib.md5(str(gene_feat).encode("utf-8")).hexdigest(),
             },
-            'get_detail': lambda : { 
+            'get_detail': lambda gene_feat : { 
                 '__donor_info': gene_feat.donor_info,
                 '__gene': gene_feat.gene,
                 '__probe_ids': gene_feat.probe_ids,
@@ -310,6 +311,7 @@ def get_regional_feature(
                 '__z_scores': gene_feat.z_scores,
                 '__expression_levels': gene_feat.expression_levels
              },
+             'instance': gene_feat,
         } for gene_feat in got_features]
     if feature_classes[modality_id] == connectivity_export.ConnectivityProfile:
         shaped_features=[{
@@ -321,10 +323,11 @@ def get_regional_feature(
                 # "kgSchema": conn_pr.kg_schema,
                 # "kgId": conn_pr.kg_id,
             },
-            'get_detail': lambda : { 
+            'get_detail': lambda conn_pr: { 
                 "__column_names": conn_pr.column_names,
                 "__profile": conn_pr.profile,
-             }
+             },
+             'instance': conn_pr,
         } for conn_pr in got_features]
     if feature_classes[modality_id] == receptors_export.ReceptorDistribution:
         shaped_features=[{
@@ -333,7 +336,7 @@ def get_regional_feature(
                 "name": receptor_pr.name,
                 "info": receptor_pr.info,
             },
-            'get_detail': lambda : { 
+            'get_detail': lambda receptor_pr: { 
                 "__receptor_symbols": receptors_export.RECEPTOR_SYMBOLS,
                 "__files": receptor_pr.files,
                 "__data": {
@@ -342,7 +345,8 @@ def get_regional_feature(
                     "__fingerprint": receptor_pr.fingerprint,
                     "__profile_unit": receptor_pr.profile_unit,
                 },
-             }
+             },
+             'instance': receptor_pr,
         } for receptor_pr in got_features]
 
     if shaped_features is None:
@@ -354,7 +358,7 @@ def get_regional_feature(
         shaped_features = [ f for f in shaped_features if f['summary']['@id'] == feature_id]
     return [{
         **f['summary'],
-        **(f['get_detail']() if detail else {})
+        **(f['get_detail'](f['instance']) if detail else {})
     } for f in shaped_features ]
 
 


### PR DESCRIPTION
Fetching ebrains features often takes ~20seconds for each individual requests. This can be drastically cut down by preheating (pre-fetching/pre-init) data features on a per parcellatino basis (see https://github.com/FZJ-INM1-BDA/siibra-python/pull/61 for performance comparison)

whilst to take advantage of preheating feature requires https://github.com/FZJ-INM1-BDA/siibra-python/pull/61 to be merged, this PR can be merged without, as it checks if `preheat` property exists.

This PR also fixes https://github.com/FZJ-INM1-BDA/siibra-api/issues/25#issuecomment-868360221 . Though if you wish, I could break it into separate PR's.