### PR TITLE
fix malformed connectivity models

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,7 +1,7 @@
-from typing import Callable, ClassVar, Dict, List
-from pydantic import BaseModel, Field, PrivateAttr
+from typing import Callable, ClassVar, Dict, Generic, List, TypeVar, Union
+from pydantic import BaseModel, Field
 from functools import wraps
-from abc import ABC
+from siibra.features.connectivity import ConnectivityMatrixDataModel, ConnectivityMatrix
 
 class HrefModel(BaseModel):
     href: str
@@ -33,3 +33,10 @@ class RestfulModel(BaseModel):
         cls._decorated_links = dict()
         return super().__init_subclass__()
 
+class SerializationErrorModel(BaseModel):
+    type: str = Field("spy/serialization-error", const=True)
+    message: str
+
+SPyParcellationFeature = ConnectivityMatrix
+
+SPyParcellationFeatureModel = Union[ConnectivityMatrixDataModel, SerializationErrorModel]

--- a/app/service/request_utils.py
+++ b/app/service/request_utils.py
@@ -13,15 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-import siibra
+from typing import List, Optional
 import nibabel as nib
-from fastapi import HTTPException
-from app.configuration.cache_redis import CacheRedis
 import hashlib
 import os
-from app.configuration.diskcache import CACHEDIR
+from fastapi import HTTPException
 
+
+from app.configuration.cache_redis import CacheRedis
+from app.configuration.diskcache import CACHEDIR
+from app.models import SPyParcellationFeature
+
+import siibra
 from siibra.core import Region, Parcellation, Space, BoundingBox
 from siibra.core.serializable_concept import JSONSerializable
 from siibra.features import FeatureQuery, modalities
@@ -119,7 +122,7 @@ def get_all_serializable_regional_features(region: Region, space: Space=None) ->
         for feat in siibra.get_features(region, modality=mod, space=space)]
 
 
-def get_all_serializable_parcellation_features(parcellation: Parcellation, **kwargs):
+def get_all_serializable_parcellation_features(parcellation: Parcellation, **kwargs) -> List[SPyParcellationFeature]:
     
     supported_modalities: List[str] = []
     for modality, query_list in [(modality, FeatureQuery._implementations[modality]) for modality in modalities]:
@@ -160,3 +163,9 @@ def get_all_serializable_spatial_features(space: Space, parcellation: Parcellati
         status_code=400,
         detail=f"parcellation, region or bbox are required"
     )
+
+def pagination_common_params(per_page: Optional[int] = 20, page: Optional[int] = 0):
+    return {
+        'per_page': per_page,
+        'page': page,
+    }


### PR DESCRIPTION
Some connectivity browser cannot be properly serialized. 

issue tracked: https://github.com/FZJ-INM1-BDA/siibra-python/issues/162

Currently, if the model cannot be serialized, it be replaced with an instance of `SerializationErrorModel` 