### PR TITLE
bugfix:  module 'jinja2' has no attribute 'contextfunction'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use fastapi python 3.7 as base image
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
+FROM python:3.7
 
 # Upgrade pip to latest version
 RUN python -m pip install --upgrade pip
@@ -43,4 +43,4 @@ EXPOSE 5000
 # Start application
 # SIIBRA_CONFIG_GITLAB_PROJECT_TAG will be set to empty string if DEV_FLAG build arg is unset
 # It needs to be unset, in this case, or the empty string will be parsed as truthy in python
-ENTRYPOINT ["/bin/bash", "-c", "if [ -z $SIIBRA_CONFIG_GITLAB_PROJECT_TAG ]; then unset SIIBRA_CONFIG_GITLAB_PROJECT_TAG; fi && uvicorn app.app:app --host 0.0.0.0 --port 5000"]
+ENTRYPOINT ["/bin/bash", "-c", "if [ -z $SIIBRA_CONFIG_GITLAB_PROJECT_TAG ]; then unset SIIBRA_CONFIG_GITLAB_PROJECT_TAG; fi && uvicorn app.app:app --host 0.0.0.0 --port 5000 --workers 4"]


### PR DESCRIPTION
jinja2 3.1.0 (dependency of starlette) `contextfunction` was renamed  (https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0) .

The source image `FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7` seems to have starlette (0.14.2) installed, but not of jinja2. 

As a result, starlette (0.14.2) and jinja2 (latest, 3.1.1) is installed, results in 

```
AttributeError: module 'jinja2' has no attribute 'contextfunction'
```

This PR should fix this issue. 


---

This PR also adds `--workers 4` to entry point. Most operations seems to be network bound. Adding the flag should increase bandwidth with no downside.