### PR TITLE
feat: use separate log file based on hostname & use lazy_path converter

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,7 +24,10 @@ from siibra import logger as siibra_logger
 from .util.route_converter import add_lazy_path
 add_lazy_path()
 
-logger = logging.getLogger(__name__)
+main_logger = logging.getLogger(__name__)
+main_logger.setLevel(logging.INFO)
+
+logger = logging.getLogger(__name__ + ".info")
 access_logger = logging.getLogger(__name__ + ".access_log")
 
 ch = logging.StreamHandler()
@@ -34,8 +37,12 @@ logger.addHandler(ch)
 logger.setLevel('INFO')
 
 
-if os.environ.get("SIIBRA_API_ACCESS_LOG_FILE"):
-    access_log_handler = TimedRotatingFileHandler(os.environ.get("SIIBRA_API_ACCESS_LOG_FILE"), when="d", encoding="utf-8")
+log_dir = os.environ.get("SIIBRA_API_LOG_DIR")
+
+if log_dir:
+    import socket
+    filename = log_dir + f"/{socket.gethostname()}.access.log"
+    access_log_handler = TimedRotatingFileHandler(filename, when="d", encoding="utf-8")
 else:
     access_log_handler = logging.StreamHandler()
 
@@ -45,8 +52,10 @@ access_log_handler.setLevel(logging.INFO)
 access_logger.addHandler(access_log_handler)
 
 
-if os.environ.get("SIIBRA_API_GENERAL_LOG_FILE"):
-    warn_fh = TimedRotatingFileHandler(os.environ.get("SIIBRA_API_GENERAL_LOG_FILE"), when="d", encoding="utf-8")
+if log_dir:
+    import socket
+    filename = log_dir + f"/{socket.gethostname()}.general.log"
+    warn_fh = TimedRotatingFileHandler(filename, when="d", encoding="utf-8")
     warn_fh.setLevel(logging.INFO)
     warn_fh.setFormatter(formatter)
     logger.addHandler(warn_fh)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -40,8 +40,11 @@ logger.setLevel('INFO')
 log_dir = os.environ.get("SIIBRA_API_LOG_DIR")
 
 if log_dir:
+    log_dir += '' if log_dir.endswith('/') else '/'
+
+if log_dir:
     import socket
-    filename = log_dir + f"/{socket.gethostname()}.access.log"
+    filename = log_dir + f"{socket.gethostname()}.access.log"
     access_log_handler = TimedRotatingFileHandler(filename, when="d", encoding="utf-8")
 else:
     access_log_handler = logging.StreamHandler()
@@ -54,7 +57,7 @@ access_logger.addHandler(access_log_handler)
 
 if log_dir:
     import socket
-    filename = log_dir + f"/{socket.gethostname()}.general.log"
+    filename = log_dir + f"{socket.gethostname()}.general.log"
     warn_fh = TimedRotatingFileHandler(filename, when="d", encoding="utf-8")
     warn_fh.setLevel(logging.INFO)
     warn_fh.setFormatter(formatter)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,6 +18,12 @@ from logging.handlers import TimedRotatingFileHandler
 import os
 from siibra import logger as siibra_logger
 
+# The patching has to be done before any other imports of starlette
+# once fastapi uses 0.19.0 https://www.starlette.io/release-notes/#0190
+# use register_url_convertor directly instead of weird patching
+from .util.route_converter import add_lazy_path
+add_lazy_path()
+
 logger = logging.getLogger(__name__)
 access_logger = logging.getLogger(__name__ + ".access_log")
 

--- a/app/app.py
+++ b/app/app.py
@@ -67,7 +67,6 @@ tags_metadata = [
     },
 ]
 
-ATLAS_PATH = '/atlases'
 siibra_version_header = 'x-siibra-api-version'
 
 # Main fastAPI application

--- a/app/core/atlas_api.py
+++ b/app/core/atlas_api.py
@@ -32,8 +32,8 @@ from siibra import atlases
 ATLAS_PATH = "/atlases"
 router = APIRouter(prefix=ATLAS_PATH)
 
-router.include_router(parcellation_router, prefix="/{atlas_id:path}")
-router.include_router(space_router, prefix="/{atlas_id:path}")
+router.include_router(parcellation_router, prefix="/{atlas_id:lazy_path}")
+router.include_router(space_router, prefix="/{atlas_id:lazy_path}")
 
 
 class SapiAtlasModel(Atlas.to_model.__annotations__.get("return"), RestfulModel):
@@ -54,7 +54,7 @@ def get_all_atlases():
     return [SapiAtlasModel.from_atlas(atlas) for atlas in atlases]
 
 
-@router.get('/{atlas_id:path}', tags=['atlases'], response_model=SapiAtlasModel)
+@router.get('/{atlas_id:lazy_path}', tags=['atlases'], response_model=SapiAtlasModel)
 @version(1)
 @SapiAtlasModel.decorate_link("self")
 def get_atlas_by_id(atlas_id: str):

--- a/app/core/feature_api.py
+++ b/app/core/feature_api.py
@@ -15,7 +15,7 @@ router = APIRouter(prefix=FEATURE_PATH)
 TAGS=["features"]
 
 
-@router.get("/{feature_id:path}", tags=TAGS,
+@router.get("/{feature_id:lazy_path}", tags=TAGS,
             response_model=UnionRegionalFeatureModels)
 def get_feature_details(feature_id: str,
                         atlas_id: Optional[str] = None,

--- a/app/core/parcellation_api.py
+++ b/app/core/parcellation_api.py
@@ -26,14 +26,12 @@ from app.service.validation import validate_and_return_atlas, validate_and_retur
 from app.core.region_api import router as region_router, get_all_regions_from_atlas_parc_space
 from app.models import RestfulModel, SPyParcellationFeatureModel, SerializationErrorModel
 
-preheat_flag = False
-
 
 PARCELLATION_PATH = "/parcellations"
 TAGS = ["parcellations"]
 
 router = APIRouter(prefix=PARCELLATION_PATH)
-router.include_router(region_router, prefix="/{parcellation_id:path}")
+router.include_router(region_router, prefix="/{parcellation_id:lazy_path}")
 
 
 class SapiParcellationModel(Parcellation.to_model.__annotations__.get("return"), RestfulModel):
@@ -69,7 +67,7 @@ def get_all_parcellations(atlas_id: str):
     return [SapiParcellationModel.from_parcellation(p) for p in atlas.parcellations]
 
 
-@router.get('/{parcellation_id:path}/features/{feature_id}',
+@router.get('/{parcellation_id:lazy_path}/features/{feature_id:lazy_path}',
             tags=TAGS,
             response_model=SPyParcellationFeatureModel)
 def get_single_detailed_global_feature(
@@ -99,7 +97,7 @@ def get_single_detailed_global_feature(
         )
 
 
-@router.get('/{parcellation_id:path}/features',
+@router.get('/{parcellation_id:lazy_path}/features',
             tags=TAGS,
             response_model=List[SPyParcellationFeatureModel])
 @SapiParcellationModel.decorate_link("features")
@@ -141,7 +139,7 @@ def get_all_global_features_for_parcellation(
     return return_list
 
 
-@router.get('/{parcellation_id:path}/volumes',
+@router.get('/{parcellation_id:lazy_path}/volumes',
             tags=TAGS,
             response_model=List[VolumeModel])
 @SapiParcellationModel.decorate_link("volumes")
@@ -156,7 +154,7 @@ def get_volumes_for_parcellation(
     return [vol.to_model() for vol in parcellation.volumes]
 
 
-@router.get('/{parcellation_id:path}',
+@router.get('/{parcellation_id:lazy_path}',
             tags=TAGS,
             response_model=SapiParcellationModel)
 @SapiParcellationModel.decorate_link("self")

--- a/app/core/region_api.py
+++ b/app/core/region_api.py
@@ -57,7 +57,7 @@ def get_all_regions_from_atlas_parc_space(
 
 
 
-@router.get("/{region_id}/features",
+@router.get("/{region_id:lazy_path}/features",
             tags=TAGS,
             response_model=List[UnionRegionalFeatureModels])
 def get_all_regional_features_for_region(
@@ -84,7 +84,7 @@ def get_all_regional_features_for_region(
         return [feat.to_model(space=space) for feat in get_all_serializable_regional_features(region, space) if feat.to_model().type == type]
 
 
-@router.get("/{region_id}/features/{feature_id:path}",
+@router.get("/{region_id:lazy_path}/features/{feature_id:lazy_path}",
             tags=TAGS,
             response_model=UnionRegionalFeatureModels)
 def get_single_detailed_regional_feature(
@@ -164,7 +164,7 @@ class NiiMetadataModel(BaseModel):
     max: float
 
 
-@router.get("/{region_id}/regional_map/info",
+@router.get("/{region_id:lazy_path}/regional_map/info",
             tags=TAGS,
             response_model=NiiMetadataModel)
 @regional_map_route_decorator()
@@ -184,7 +184,7 @@ def get_regional_map_info(cached_fullpath: str):
     }
 
 
-@router.get("/{region_id}/regional_map/map",
+@router.get("/{region_id:lazy_path}/regional_map/map",
             tags=TAGS,
             responses=file_response_openapi)
 @regional_map_route_decorator()
@@ -195,7 +195,7 @@ def get_regional_map_file(cached_fullpath: str):
     return FileResponse(cached_fullpath, media_type='application/octet-stream')
 
 
-@router.get("/{region_id}",
+@router.get("/{region_id:lazy_path}",
             tags=TAGS,
             response_model=Region.to_model.__annotations__.get("return"))
 def get_single_region_detail(

--- a/app/core/space_api.py
+++ b/app/core/space_api.py
@@ -73,7 +73,7 @@ def get_all_spaces(atlas_id: str):
     return [SapiSpaceModel.from_space(space) for space in atlas.spaces]
 
 
-@router.get("/{space_id:path}/templates",
+@router.get("/{space_id:lazy_path}/templates",
     tags=TAGS,
     responses=file_response_openapi)
 def get_template_by_space_id(atlas_id: str, space_id: str):
@@ -91,7 +91,7 @@ def get_template_by_space_id(atlas_id: str, space_id: str):
     return FileResponse(filename, filename=filename, media_type='application/octet-stream')
 
 
-@router.get("/{space_id:path}/parcellation_maps",
+@router.get("/{space_id:lazy_path}/parcellation_maps",
     tags=TAGS,
     responses=file_response_openapi)
 # add parcellations_map_id as optional param
@@ -140,7 +140,7 @@ def get_parcellation_map_for_space(atlas_id: str, space_id: str):
         detail='Maps for space with id: {} not found'.format(space_id))
 
 
-@router.get("/{space_id:path}/features/{feature_id}",
+@router.get("/{space_id:lazy_path}/features/{feature_id}",
     tags=TAGS,
     response_model=UnionSpatialFeatureModels)
 def get_single_detailed_spatial_feature(
@@ -172,7 +172,7 @@ def get_single_detailed_spatial_feature(
             detail=f"feature with id {feature_id} not found."
         )
 
-@router.get("/{space_id:path}/features",
+@router.get("/{space_id:lazy_path}/features",
     tags=TAGS,
     response_model=List[UnionSpatialFeatureModels])
 @SapiSpaceModel.decorate_link("features")
@@ -197,7 +197,7 @@ def get_all_spatial_features_for_space(
     return [feat.to_model(detail=False) for feat in features]
 
 
-@router.get("/{space_id:path}/volumes",
+@router.get("/{space_id:lazy_path}/volumes",
     tags=TAGS,
     response_model=List[VolumeModel])
 @SapiSpaceModel.decorate_link("volumes")
@@ -207,7 +207,7 @@ def get_volumes_for_space(atlas_id: str, space_id: str):
     return [vol.to_model() for vol in space.volumes]
 
 
-@router.get("/{space_id:path}",
+@router.get("/{space_id:lazy_path}",
     tags=TAGS,
     response_model=SapiSpaceModel)
 @SapiSpaceModel.decorate_link("self")

--- a/app/util/route_converter.py
+++ b/app/util/route_converter.py
@@ -1,0 +1,82 @@
+def add_lazy_path():
+    """
+    adds lazy_path path converter for starlette route
+
+    For example:
+
+    "GET /atlases/juelich%2Fiav%2Fatlas%2Fv1.0.0%2F1/parcellations/minds%2Fcore%2Fparcellationatlas%2Fv1.0.0%2F94c1125b-b87e-45e4-901c-00daee7f2579-290/regions/Area%20hOc1%20%28V1%2C%2017%2C%20CalcS%29%20right/features/siibra%2Ffeatures%2Fcells%2Fhttps%3A%2F%2Fopenminds.ebrains.eu%2Fcore%2FDatasetVersion%2Fc1438d1996d1d2c86baa05496ba28fc5"
+
+    or 
+
+    ```python
+    "/atlases/{atlas_id}/parcellations/{parc_id}/regions/{region_id}/features/{feat_id}".format(
+        atlas_id="juelich%2Fiav%2Fatlas%2Fv1.0.0%2F1",
+        parc_id="minds%2Fcore%2Fparcellationatlas%2Fv1.0.0%2F94c1125b-b87e-45e4-901c-00daee7f2579-290",
+        region_id="Area%20hOc1%20%28V1%2C%2017%2C%20CalcS%29%20right",
+        feat_id="siibra%2Ffeatures%2Fcells%2Fhttps%3A%2F%2Fopenminds.ebrains.eu%2Fcore%2FDatasetVersion%2Fc1438d1996d1d2c86baa05496ba28fc5",
+    )
+    ```
+
+    default path converter (eager) will:
+    1/ deserialize URI encoded characters, resulting in:
+    ```python
+    "/atlases/{atlas_id}/parcellations/{parc_id}/regions/{region_id}/features/{feat_id}".format(
+        atlas_id="juelich/iav/atlas/v1.0.0/1",
+        parc_id="minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579-290",
+        region_id="Area hOc1 (V1, 17, CalcS) right",
+        feat_id="siibra/features/cells/https://openminds.ebrains.eu/core/DatasetVersion/c1438d1996d1d2c86baa05496ba28fc5",
+    )
+    ```
+    2/ try to eager match, resulting in errorenous parsing of the path:
+
+    ```python
+    "/atlases/{atlas_id}/parcellations/{parc_id}/regions/{region_id}/features/{feat_id}".format(
+        atlas_id="juelich/iav/atlas/v1.0.0/1",
+        parc_id="minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579-290",
+        region_id="Area hOc1 (V1, 17, CalcS) right/features/siibra",
+        feat_id="cells/https://openminds.ebrains.eu/core/DatasetVersion/c1438d1996d1d2c86baa05496ba28fc5",
+    )
+    ```
+
+    The lazy path converter is not without its (potential) issue:
+
+    For example:
+
+    "GET /atlases/foo-bar/parcellations/parc%2Ffeatures%2Ffoo/features"
+
+    or 
+
+    ```python
+    "/atlases/{atlas_id}/parcellations/{parc_id}/features".format(
+        atlas_id="foo-bar",
+        parc_id="parc%2Ffeatures%2Ffoo"
+    )
+    ```
+
+    1/ deserialization of URI encoded characters, resulting in:
+
+    ```python
+    "/atlases/{atlas_id}/parcellations/{parc_id}/features".format(
+        atlas_id="foo-bar",
+        parc_id="parc/features/foo"
+    )
+    ```
+    
+    2/ trying to lazy match, resulting in errorenous parsing of the path:
+
+    ```python
+    "/atlases/{atlas_id}/parcellations/{parc_id}/features/{features_id}".format(
+        atlas_id="foo-bar",
+        parc_id="parc",
+        features_id="foo"
+    )
+    ```
+
+    Most ideally, the starlette routing should split path first, then decode the encoded characters
+    """
+    from starlette.convertors import PathConvertor, CONVERTOR_TYPES
+
+    class LazyPathConverter(PathConvertor):
+        regex = ".*?"
+
+    CONVERTOR_TYPES['lazy_path'] = LazyPathConverter()


### PR DESCRIPTION
This PR introduces two changes:

- introduced `lazy_path` path converter. The rationale (and some examples) are outlined in https://github.com/FZJ-INM1-BDA/siibra-api/blob/fabdd05/app/util/route_converter.py#L2-L76

- using different log files based on hostname. It appears that whilst workers in gunicorn managed instance append the log civilly, in a multipod environment (k8s/openshift) sharing the same write volume results in racing append to log file. 