### PR TITLE
fix space feature id

### DIFF
--- a/app/core/space_api.py
+++ b/app/core/space_api.py
@@ -140,7 +140,7 @@ def get_parcellation_map_for_space(atlas_id: str, space_id: str):
         detail='Maps for space with id: {} not found'.format(space_id))
 
 
-@router.get("/{space_id:lazy_path}/features/{feature_id}",
+@router.get("/{space_id:lazy_path}/features/{feature_id:lazy_path}",
     tags=TAGS,
     response_model=UnionSpatialFeatureModels)
 def get_single_detailed_spatial_feature(

--- a/test/core/test_regions_api.py
+++ b/test/core/test_regions_api.py
@@ -175,7 +175,7 @@ class TestSingleRegionFeatures(unittest.TestCase):
         url = '/v1_0/atlases/{}/parcellations/{}/regions/{}/features/{}'.format(
             quote_plus(ATLAS_ID),
             PARCELLATION_ID,
-            REGION_BASAL,
+            HOC1_LEFT_REGION_NAME,
             VALID_FEATURE_ID)
         response = client.get(url)
 

--- a/test/core/test_regions_api.py
+++ b/test/core/test_regions_api.py
@@ -30,10 +30,8 @@ HOC1_REGION_ID = 'minds%2Fcore%2Fparcellationregion%2Fv1.0.0%2F5151ab8f-d8cb-4e6
 INVALID_REGION_NAME = 'INVALID_REGION'
 SPACE_ID = 'minds%2Fcore%2Freferencespace%2Fv1.0.0%2Fdafcffc5-4826-4bf1-8ff6-46b8a31ff8e2'
 FS_AVERAGE_SPACE_ID='minds/core/referencespace/v1.0.0/tmp-fsaverage'
-VALID_MODALITY='EbrainsRegionalDataset'
-VALID_MODALITY_INSTANCE_ID='https%3A%2F%2Fnexus.humanbrainproject.org%2Fv0%2Fdata%2Fminds%2Fcore%2Fdataset%2Fv1.0.0%2F87c6dea7-bdf7-4049-9975-6a9925df393f'
-INVALID_FEATURE = 'INVALID'
-VALID_MODALITY_ID = 'https://nexus.humanbrainproject.org/v0/data/minds/core/dataset/v1.0.0/de08dcb8-28d4-4f8f-b019-ef0f8924d5d4'
+INVALID_FEATURE_ID = 'INVALID'
+VALID_FEATURE_ID = 'siibra/features/receptor/33c1e49ddd06eed636eb35e747378f40'
 
 def test_all_regions_for_parcellations():
     response = client.get('/v1_0/atlases/{}/parcellations/{}/regions?space_id={}'.format(
@@ -178,7 +176,7 @@ class TestSingleRegionFeatures(unittest.TestCase):
             quote_plus(ATLAS_ID),
             PARCELLATION_ID,
             REGION_BASAL,
-            VALID_MODALITY_ID)
+            VALID_FEATURE_ID)
         response = client.get(url)
 
         # result_content = json.loads(response.content)
@@ -189,7 +187,7 @@ class TestSingleRegionFeatures(unittest.TestCase):
             quote(ATLAS_ID),
             PARCELLATION_ID,
             quote(HOC1_LEFT_REGION_NAME),
-            INVALID_FEATURE))
+            INVALID_FEATURE_ID))
         assert response.status_code == 404
 
     #TODO not yet implemented with pydantic

--- a/test/core/test_space_api.py
+++ b/test/core/test_space_api.py
@@ -10,6 +10,7 @@ client = TestClient(app)
 ATLAS_ID = 'juelich/iav/atlas/v1.0.0/1'
 SPACE_ID = 'minds%2Fcore%2Freferencespace%2Fv1.0.0%2Fdafcffc5-4826-4bf1-8ff6-46b8a31ff8e2'
 INVALID_SPACE_ID = 'INVALID_SPACE_ID'
+url_tmpl='/v1_0/atlases/{}/spaces/{}/features{}?parcellation_id={}&region={}'
 
 
 # class MockRegionProps:
@@ -48,7 +49,6 @@ def test_get_invalid_space():
     assert result_content['detail'] == f'space_id: {INVALID_SPACE_ID} is not known'
 
 def test_ieeg_spatial_feature():
-    url_tmpl='/v1_0/atlases/{}/spaces/{}/features{}?parcellation_id={}&region={}'
 
     # first get all spatial features given jba2.9 and hoc1 right
     url=url_tmpl.format(
@@ -103,7 +103,18 @@ def test_ieeg_spatial_feature():
             if not electrode.in_roi
             for contact_pt in electrode.contact_points.values()
         )
+def test_resolve_single_detailed_feature():
     
+    resp = client.get(
+        url_tmpl.format(
+            'juelich/iav/atlas/v1.0.0/1',
+            'minds/core/referencespace/v1.0.0/dafcffc5-4826-4bf1-8ff6-46b8a31ff8e2',
+            '/siibra/features/ieegSession/d11d92a6e925f158254f3ac1df2e33cf:HID-Sub-018',
+            'minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579-290',
+            'Area%20hOc1%20(V1,%2017,%20CalcS)%20right'
+        ),
+    )
+    assert resp.status_code == 200
 
 def test_get_templates_for_space():
     pass

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -1,4 +1,3 @@
-from _pytest.mark import param
 import pytest
 import json
 from httpx import AsyncClient


### PR DESCRIPTION
add test to prevent regression

added lazy_path path converter to feature id for space features. 

Previously, queries such as 

```
curl 'http://localhost:5000/v1_0/atlases/juelich%2Fiav%2Fatlas%2Fv1.0.0%2F1/spaces/minds%2Fcore%2Freferencespace%2Fv1.0.0%2Fdafcffc5-4826-4bf1-8ff6-46b8a31ff8e2/features/siibra%2Ffeatures%2FieegSession%2Fd11d92a6e925f158254f3ac1df2e33cf%3AHID-Sub-018?parcellation_id=minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579-290&region=Area%20hOc1%20(V1,%2017,%20CalcS)%20right'
```

result in the incorrect parsing of path parameters.

can you take a look at this PR too @marcenko ?