### PR TITLE
added types to modalities endpoint & catching logging gateway timeout

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -367,7 +367,6 @@ async def runtime_exception_handler(request: Request, exc: RuntimeError):
     :return: HTTP status 503 with a custom message
     """
     logging.warning(str(exc))
-    print('handler!!')
     return JSONResponse(
         status_code=503,
         content={

--- a/app/core/siibra_api.py
+++ b/app/core/siibra_api.py
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
 from fastapi import APIRouter
 from fastapi.encoders import jsonable_encoder
 import siibra
-
+from siibra.core.serializable_concept import JSONSerializable
 
 router = APIRouter()
 
@@ -41,6 +40,8 @@ def get_all_available_modalities():
     """
     return [{
         'name': feature_name,
-        'type': ''
+        'types': set([ FeatureQuery._FEATURETYPE.get_model_type()
+            for FeatureQuery in siibra.features.FeatureQuery._implementations[feature_name]
+            if issubclass(FeatureQuery._FEATURETYPE, JSONSerializable) ])
     } for feature_name in siibra.features.modalities]
 


### PR DESCRIPTION
This PR adds types (as `List[str]`) to the `/modalities` end point.

Additionally, this PR also logs potential gateway timeouts (prevoiusly not logged)

@marcenko Could you take a look at this PR too? The changes to the shape of json return in `/modalities` gives me a little pause, but given that `FeatureQuery._implementations` has the type of `Dict[str, List[FeatureQuery]]`, there is very little we could do. 

I did use a `set()` to remove duplicates (of which there are a few)